### PR TITLE
 implement optional logging w/ custom_logging option

### DIFF
--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -60,6 +60,12 @@
 #   and the value is an array of config lines. Default: empty
 #  $includes:
 #   Array of absolute paths to named.conf include files. Default: empty
+#  $logging:
+#   Boolean to include default logging options
+#   Default: true
+#  $custom_logging:
+#   Hash of logging options (currently limited to ['category','channel'] per named.conf
+#   Example: {channel => {security => {key => val, }}, category => {security => {}}
 #
 # Sample Usage :
 #  bind::server::conf { '/etc/named.conf':

--- a/manifests/server/conf.pp
+++ b/manifests/server/conf.pp
@@ -107,6 +107,8 @@ define bind::server::conf (
   $allow_query            = [ 'localhost' ],
   $allow_query_cache      = [],
   $recursion              = 'yes',
+  $logging                = true,
+  $custom_logging         = {},
   $allow_recursion        = [],
   $allow_transfer         = [],
   $check_names            = [],

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -98,6 +98,7 @@ options {
     bindkeys-file "/etc/named.iscdlv.key";
 };
 
+<% if @logging -%>
 logging {
     channel main_log {
         file "/var/log/named/named.log" versions 3 size 5m;
@@ -112,7 +113,20 @@ logging {
     category lame-servers {
         null;
     };
+<% if @custom_logging and !@custom_logging.empty? -%>
+<% @custom_logging.each do |log_type,log_hashes| -%>
+<% log_hashes.each do |name,log_hash| -%>
+    <%= log_type %> <%= name %> {
+<% log_hash.each do |key,val| -%>
+        <%= key %> <%= val %>;
+<% end -%>
+    };
+<% end -%>
+<% end -%>
+<% end -%>
 };
+<% end -%>
+
 <% if !@views.empty? -%>
 
 <% @views.sort_by {|key,value| key}.each do |key,value| -%>


### PR DESCRIPTION
- add boolean to control `logging` 
    - useful for managed/custom logs beyond puppet scope (separate config file)
    - useful for admins that wish to disable logging
    - defaults to *true*
- adds `custom_logging` hash
  - relies on hash format of:  ` { 'channel|category' => { name => {key => val} } }`
  - `named.conf` equillivent
```
  channel name {
    key val;
  };

  category name {
    key val;
  };
```

##### Reason
When adding data collectors (ie. prometheus exporters) - its nice to have segregated logging as an option. Cuts down on the amount of data the collector must parse as well as allows for easier debugging when applied properly (YMMV.) 

##### Example configuration
> This is my current setup (with all of the fun stuff redacted)
```
  bind::server::conf {'/etc/named.conf':
    custom_logging => {
      channel => {
        security_log => {
          file => '"/var/log/named/security.log" versions 3 size 30m',
	  severity => 'dynamic',
          print-time => 'yes',
        },
      }, 
      category => {
        security => { 
          security_log => '', 
        },
      },
    },
  }
```